### PR TITLE
Shorten lazada URL

### DIFF
--- a/fareview/pipelines.py
+++ b/fareview/pipelines.py
@@ -17,7 +17,7 @@ class ExistingProductPricePipeline:
     Update existing products information
     Create a new price for existing products if the new price differs from the existing price
 
-    `url` and `quantity` is used to define the uniqueness of a product
+    `brand`, `url` and `quantity` is used to define the uniqueness of a product
     Using `url` alone isn't enough because the same URL (product) can have type of different `quantity`
     E.g.: "Pabst Blue Ribbon American Lager" can be of 'Single', '6 Packs' or 'Case of 24'
 
@@ -39,6 +39,7 @@ class ExistingProductPricePipeline:
         assert spider
         adapter = ItemAdapter(item)
 
+        name = adapter['name']
         brand = adapter['brand']
         url = adapter['url']
         quantity = adapter['quantity']
@@ -59,12 +60,13 @@ class ExistingProductPricePipeline:
 
         if existing_product is not None:
             # Always update information for existing products
-            product = dict(
+            product_to_update = dict(
                 id=existing_product.id,
+                name=name,
                 review_count=adapter.get('review_count'),
                 attributes=adapter.get('attributes'),
             )
-            self.products_update.append(product)
+            self.products_update.append(product_to_update)
 
             # Create new price object for the product
             if existing_product.last_price != new_price:
@@ -138,7 +140,7 @@ class NewProductPricePipeline:
             url=adapter['url'],
             quantity=adapter['quantity'],
             review_count=adapter['review_count'],
-            attributes=adapter['attributes'],
+            attributes=adapter.get('attributes'),
             price=adapter['price'].amount
         )
 

--- a/fareview/spiders/lazada.py
+++ b/fareview/spiders/lazada.py
@@ -69,9 +69,12 @@ class LazadaSpider(scrapy.Spider):
                 if int(review_count) < 5:
                     continue
 
+                item_id = product['itemId']
+                shop_id = product['sellerId']
+
                 attributes = dict(
-                    item_id=product.get('itemId'),
-                    shop_id=product.get('sellerId'),
+                    item_id=item_id,
+                    shop_id=shop_id,
                     sku_id=product.get('skuId'),
                     discount=product.get('discount'),
                     in_stock=product.get('inStock'),
@@ -84,7 +87,7 @@ class LazadaSpider(scrapy.Spider):
                 loader.add_value('name', product['name'])
                 loader.add_value('brand', product['brandName'].lower())
                 loader.add_value('vendor', product['sellerName'])
-                loader.add_value('url', 'https:' + product['productUrl'])
+                loader.add_value('url', f'https://www.lazada.sg/products/-i{item_id}-s{shop_id}.html')  # We could also use `productUrl` here
 
                 loader.add_value('quantity', product['name'])
                 loader.add_value('review_count', review_count)


### PR DESCRIPTION
Why? Because lazada API kept returning the same exact product with the same item_id but a different URL. So, using lazada's `productUrl` isn't going to be accurate.

You will need to run this one-off script on production:
```python
# Script to update lazada URL

from sqlalchemy.orm import sessionmaker
from fareview.models import Price, Product, create_table, db_connect

engine = db_connect()
create_table(engine)
x_session = sessionmaker(bind=engine)
session = x_session()

products = session.query(Product).filter(Product.platform=='lazada').all()

for p in products:
    item_id = p.attributes.get('item_id')
    shop_id = p.attributes.get('shop_id')

    p.url = f'https://www.lazada.sg/products/-i{item_id}-s{shop_id}.html'
    session.commit()
```